### PR TITLE
Fix obtaining existing member id from the ./keys dir

### DIFF
--- a/Controllers/ApplicationController.cs
+++ b/Controllers/ApplicationController.cs
@@ -182,7 +182,7 @@ namespace merchant_sample_csharp.Controllers
         private static Member InitializeMember(TokenClient tokenClient)
         {
             var keyDir = Directory.GetFiles("./keys");
-            
+
             var memberIds = keyDir.Where(d => d.Contains("_")).Select(d => d.Replace("_", ":"));
             
             return !memberIds.Any() 


### PR DESCRIPTION
Fixed the way the existing member id is obtained from the content of the ./keys dir, so that the existing member is loaded from the DB 